### PR TITLE
Home work 6 02 12 2017

### DIFF
--- a/src/main/java/hillelJavaEE_02/doctor/DoctorConfig.java
+++ b/src/main/java/hillelJavaEE_02/doctor/DoctorConfig.java
@@ -1,21 +1,17 @@
 package hillelJavaEE_02.doctor;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 @Configuration
-@ConfigurationProperties(prefix = "doctor-specialization")
+@ConfigurationProperties(prefix = "doctor-configuration")
+@NoArgsConstructor
+@Getter
 public class DoctorConfig {
-    private List<String> list;
-
-    DoctorConfig() {
-        this.list = new CopyOnWriteArrayList<>();
-    }
-
-    public List<String> getList() {
-        return this.list;
-    }
+    private List<String> specializations = new ArrayList<>();
 }

--- a/src/main/java/hillelJavaEE_02/doctor/DoctorConfig.java
+++ b/src/main/java/hillelJavaEE_02/doctor/DoctorConfig.java
@@ -1,0 +1,21 @@
+package hillelJavaEE_02.doctor;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+@Configuration
+@ConfigurationProperties(prefix = "doctor-specialization")
+public class DoctorConfig {
+    private List<String> list;
+
+    DoctorConfig() {
+        this.list = new CopyOnWriteArrayList<>();
+    }
+
+    public List<String> getList() {
+        return this.list;
+    }
+}

--- a/src/main/java/hillelJavaEE_02/doctor/DoctorController.java
+++ b/src/main/java/hillelJavaEE_02/doctor/DoctorController.java
@@ -1,7 +1,6 @@
 package hillelJavaEE_02.doctor;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
+import hillelJavaEE_02.doctor.util.ErrorBody;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -86,12 +85,5 @@ public class DoctorController {
         doctors.remove(id);
         return ResponseEntity.noContent().build();
     }
-}
-
-@Data
-@AllArgsConstructor
-class ErrorBody {
-    private final Integer code = 400;
-    private String msg;
 }
 

--- a/src/main/java/hillelJavaEE_02/doctor/DoctorController.java
+++ b/src/main/java/hillelJavaEE_02/doctor/DoctorController.java
@@ -14,6 +14,11 @@ import java.util.Optional;
 public class DoctorController {
     private final DoctorService doctorService;
 
+    @GetMapping("/doctors/specializations")
+    public List<String> getSpecializations() {
+        return doctorService.getSpecializations();
+    }
+
     @GetMapping("/doctors")
     public List<Doctor> getDoctors(@RequestParam Optional<String> specialization,
                                    @RequestParam Optional<String> name) {

--- a/src/main/java/hillelJavaEE_02/doctor/DoctorRepository.java
+++ b/src/main/java/hillelJavaEE_02/doctor/DoctorRepository.java
@@ -1,5 +1,6 @@
 package hillelJavaEE_02.doctor;
 
+import hillelJavaEE_02.doctor.util.NoSuchSpecializationException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -33,6 +34,10 @@ public class DoctorRepository {
     }
 
     public Doctor save(Doctor doctor) {
+        if(!this.findAllSpecialization().contains(doctor.getSpecialization())) {
+            throw new NoSuchSpecializationException("The specialty should be from the list in the configuration: " + doctor.getSpecialization());
+        }
+
         if (doctor.getId() == null) {
             doctor.setId(ThreadLocalRandom.current().nextInt(0, Integer.MAX_VALUE));
         }

--- a/src/main/java/hillelJavaEE_02/doctor/DoctorRepository.java
+++ b/src/main/java/hillelJavaEE_02/doctor/DoctorRepository.java
@@ -1,11 +1,9 @@
 package hillelJavaEE_02.doctor;
 
-import hillelJavaEE_02.doctor.util.NoSuchSpecializationException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -19,12 +17,6 @@ public class DoctorRepository {
         put(1, new Doctor(1, "Alex", "doctor"));
     }};
 
-    private final DoctorConfig doctorConfig;
-
-    public List<String> findAllSpecialization() {
-        return doctorConfig.getList();
-    }
-
     public Collection<Doctor> findAll() {
         return doctors.values();
     }
@@ -34,10 +26,6 @@ public class DoctorRepository {
     }
 
     public Doctor save(Doctor doctor) {
-        if(!this.findAllSpecialization().contains(doctor.getSpecialization())) {
-            throw new NoSuchSpecializationException("The specialty should be from the list in the configuration: " + doctor.getSpecialization());
-        }
-
         if (doctor.getId() == null) {
             doctor.setId(ThreadLocalRandom.current().nextInt(0, Integer.MAX_VALUE));
         }

--- a/src/main/java/hillelJavaEE_02/doctor/DoctorRepository.java
+++ b/src/main/java/hillelJavaEE_02/doctor/DoctorRepository.java
@@ -1,0 +1,37 @@
+package hillelJavaEE_02.doctor;
+
+import org.springframework.stereotype.Repository;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
+
+@Repository
+public class DoctorRepository {
+    private Map<Integer, Doctor> doctors = new ConcurrentHashMap<Integer, Doctor>() {{
+        put(0, new Doctor(0, "Doc", "surgeon"));
+        put(1, new Doctor(1, "Alex", "doctor"));
+    }};
+
+    public Collection<Doctor> findAll() {
+        return doctors.values();
+    }
+
+    public Optional<Doctor> findById(Integer id) {
+        return Optional.ofNullable(doctors.get(id));
+    }
+
+    public Doctor save(Doctor doctor) {
+        if (doctor.getId() == null) {
+            doctor.setId(ThreadLocalRandom.current().nextInt(0, Integer.MAX_VALUE));
+        }
+        doctors.put(doctor.getId(), doctor);
+        return doctor;
+    }
+
+    public Optional<Doctor> delete(Integer id) {
+        return Optional.ofNullable(doctors.remove(id));
+    }
+}

--- a/src/main/java/hillelJavaEE_02/doctor/DoctorRepository.java
+++ b/src/main/java/hillelJavaEE_02/doctor/DoctorRepository.java
@@ -1,19 +1,28 @@
 package hillelJavaEE_02.doctor;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadLocalRandom;
 
 @Repository
+@RequiredArgsConstructor
 public class DoctorRepository {
     private Map<Integer, Doctor> doctors = new ConcurrentHashMap<Integer, Doctor>() {{
         put(0, new Doctor(0, "Doc", "surgeon"));
         put(1, new Doctor(1, "Alex", "doctor"));
     }};
+
+    private final DoctorConfig doctorConfig;
+
+    public List<String> findAllSpecialization() {
+        return doctorConfig.getList();
+    }
 
     public Collection<Doctor> findAll() {
         return doctors.values();

--- a/src/main/java/hillelJavaEE_02/doctor/DoctorService.java
+++ b/src/main/java/hillelJavaEE_02/doctor/DoctorService.java
@@ -1,5 +1,6 @@
 package hillelJavaEE_02.doctor;
 
+import hillelJavaEE_02.doctor.util.NoSuchSpecializationException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -12,9 +13,10 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class DoctorService {
     private final DoctorRepository doctorRepository;
+    private final DoctorConfig doctorConfig;
 
     public List<String> getSpecializations() {
-        return doctorRepository.findAllSpecialization();
+        return doctorConfig.getSpecializations();
     }
 
     public List<Doctor> getDoctors(Optional<String> specialization,
@@ -41,6 +43,10 @@ public class DoctorService {
     }
 
     public Doctor save(Doctor doctor) {
+        if(!this.getSpecializations().contains(doctor.getSpecialization())) {
+            throw new NoSuchSpecializationException("The specialty should be from the list in the configuration: " + doctor.getSpecialization());
+        }
+
         return doctorRepository.save(doctor);
     }
 

--- a/src/main/java/hillelJavaEE_02/doctor/DoctorService.java
+++ b/src/main/java/hillelJavaEE_02/doctor/DoctorService.java
@@ -13,6 +13,10 @@ import java.util.stream.Collectors;
 public class DoctorService {
     private final DoctorRepository doctorRepository;
 
+    public List<String> getSpecializations() {
+        return doctorRepository.findAllSpecialization();
+    }
+
     public List<Doctor> getDoctors(Optional<String> specialization,
                                    Optional<String> name) {
 

--- a/src/main/java/hillelJavaEE_02/doctor/DoctorService.java
+++ b/src/main/java/hillelJavaEE_02/doctor/DoctorService.java
@@ -1,0 +1,46 @@
+package hillelJavaEE_02.doctor;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class DoctorService {
+    private final DoctorRepository doctorRepository;
+
+    public List<Doctor> getDoctors(Optional<String> specialization,
+                                   Optional<String> name) {
+
+        Predicate<Doctor> filterBySpecialization = specialization.map(this::filterBySpecialization)
+                .orElse(doctor -> true);
+        Predicate<Doctor> filterByName = name.map(this::filterByName).orElse(doctor -> true);
+        Predicate<Doctor> complexFilter = filterBySpecialization.and(filterByName);
+
+        return doctorRepository.findAll().stream().filter(complexFilter).collect(Collectors.toList());
+    }
+
+    private Predicate<Doctor> filterByName(String name) {
+        return doctor -> doctor.getName().startsWith(name);
+    }
+
+    private Predicate<Doctor> filterBySpecialization(String specialization) {
+        return doctor -> doctor.getSpecialization().equals(specialization);
+    }
+
+    public Optional<Doctor> getById(Integer id) {
+        return doctorRepository.findById(id);
+    }
+
+    public Doctor save(Doctor doctor) {
+        return doctorRepository.save(doctor);
+    }
+
+    public Optional<Doctor> delete(Integer id) {
+        return doctorRepository.delete(id);
+    }
+}

--- a/src/main/java/hillelJavaEE_02/doctor/util/ErrorBody.java
+++ b/src/main/java/hillelJavaEE_02/doctor/util/ErrorBody.java
@@ -1,0 +1,11 @@
+package hillelJavaEE_02.doctor.util;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ErrorBody {
+    private final Integer code = 400;
+    private String msg;
+}

--- a/src/main/java/hillelJavaEE_02/doctor/util/NoSuchSpecializationException.java
+++ b/src/main/java/hillelJavaEE_02/doctor/util/NoSuchSpecializationException.java
@@ -1,0 +1,11 @@
+package hillelJavaEE_02.doctor.util;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class NoSuchSpecializationException extends RuntimeException {
+    public NoSuchSpecializationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,4 @@
+doctor-specialization:
+  list:
+    - surgeon
+    - doctor

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,4 @@
-doctor-specialization:
-  list:
+doctor-configuration:
+  specializations:
     - surgeon
     - doctor


### PR DESCRIPTION
Решить проблему многопоточности использованием потокобезопасных типов данных (избегая синхронизации)
Избавиться от инкремента в генерации ID (использовать случайные значения)
Контроллер для докторов разбить на 3 слоя
Специальности докторов вынести в конфиг (разобраться как в YAML создавать список)
Добавить в API эндпоинт, возвращающий список специализаций ( GET /doctors/specializations)
Добавить проверку: при попытке создания (или изменения) доктора, его специальность должна быть из списка в конфигурации.
